### PR TITLE
Setting project restart

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,8 +43,8 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
   # gem 'konacha'
-  gem 'poltergeist'
-  gem 'phantomjs', :require => 'phantomjs/poltergeist'
+  # gem 'poltergeist'
+  # gem 'phantomjs', :require => 'phantomjs/poltergeist'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,23 +42,12 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.6.0)
-      public_suffix (>= 2.0.2, < 4.0)
     ansi (1.5.0)
     arel (9.0.0)
     bindex (0.7.0)
     builder (3.2.3)
     byebug (11.0.1)
-    capybara (3.25.0)
-      addressable
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (~> 1.5)
-      xpath (~> 3.2)
     chronic (0.10.2)
-    cliver (0.3.2)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -103,12 +92,6 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
-    phantomjs (2.1.1.0)
-    poltergeist (1.18.1)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
-    public_suffix (3.1.1)
     rack (2.0.7)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -141,7 +124,6 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rdoc (4.3.0)
-    regexp_parser (1.5.1)
     ruby-progressbar (1.10.1)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -185,8 +167,6 @@ GEM
     websocket-extensions (0.1.4)
     whenever (1.0.0)
       chronic (>= 0.6.3)
-    xpath (3.2.0)
-      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
@@ -198,8 +178,6 @@ DEPENDENCIES
   jquery-rails
   minitest-reporters (= 1.0.5)
   mysql2
-  phantomjs
-  poltergeist
   rails (~> 5.2.3)
   sass-rails
   sdoc (~> 0.4.0)

--- a/config/initializers/new_framework_defaults.rb
+++ b/config/initializers/new_framework_defaults.rb
@@ -20,4 +20,4 @@ ActiveSupport.to_time_preserves_timezone = false
 Rails.application.config.active_record.belongs_to_required_by_default = false
 
 # Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = true
+# ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
# What
rails sができるようにしました。
- phantomjsの削除
- rails 4メソッドのコメントアウト

# phantomjsとは
ヘッドレスのブラウザ、2019/7/3現在開発は終了し、githubリポジトリもアーカイブされている。
本プロジェクトではJavaScriptのテストをするために導入していた。

# phantomjs削除の対応
JavaScriptのテストも数行しか実施しておらず、再度プロジェクトをスタートするという趣旨にそれているため、テストは廃棄、phantomjs代替策も使用しない。
